### PR TITLE
Fix missing standard include files problem

### DIFF
--- a/auto-complete-clang.el
+++ b/auto-complete-clang.el
@@ -185,14 +185,13 @@ This variable will typically contain include paths, e.g., ( \"-I~/MyProject\", \
              "c++"))))
 
 (defsubst ac-clang-build-complete-args (pos)
-  (append '("-cc1" "-fsyntax-only")
+  (append '("-fsyntax-only")
           (unless ac-clang-auto-save
             (list "-x" (ac-clang-lang-option)))
           ac-clang-flags
           (when (stringp ac-clang-prefix-header)
             (list "-include-pch" (expand-file-name ac-clang-prefix-header)))
-          '("-code-completion-at")
-          (list (ac-clang-build-location pos))
+          '("-Xclang" (concat "-code-completion-at=" (ac-clang-build-location pos)))
           (list (if ac-clang-auto-save buffer-file-name "-"))))
 
 

--- a/auto-complete-clang.el
+++ b/auto-complete-clang.el
@@ -191,7 +191,7 @@ This variable will typically contain include paths, e.g., ( \"-I~/MyProject\", \
           ac-clang-flags
           (when (stringp ac-clang-prefix-header)
             (list "-include-pch" (expand-file-name ac-clang-prefix-header)))
-          '("-Xclang" (concat "-code-completion-at=" (ac-clang-build-location pos)))
+          `("-Xclang" ,(concat "-code-completion-at=" (ac-clang-build-location pos)))
           (list (if ac-clang-auto-save buffer-file-name "-"))))
 
 


### PR DESCRIPTION
This fixes the problem that completion doesn't work because of missing
standard include files.

I solved this problem by using the `clang` _driver_ instead of the `clang -cc1` _frontend_.
Clang's [FAQ](http://llvm.org/releases/3.4/tools/clang/docs/FAQ.html#id2) says it's not good idea for a user to use the frontend directly.
